### PR TITLE
Reformat using 'black' code style tool.

### DIFF
--- a/netbox_rbac/__init__.py
+++ b/netbox_rbac/__init__.py
@@ -1,1 +1,1 @@
-default_app_config = 'netbox_rbac.apps.AppConfig'
+default_app_config = "netbox_rbac.apps.AppConfig"

--- a/netbox_rbac/api.py
+++ b/netbox_rbac/api.py
@@ -1,4 +1,5 @@
 from rest_framework import permissions
 
+
 class TokenPermissions(permissions.DjangoObjectPermissions):
-	pass
+    pass

--- a/netbox_rbac/apps.py
+++ b/netbox_rbac/apps.py
@@ -5,50 +5,54 @@ import inspect
 
 # Core applications.
 apps = [
-	'circuits',
-	'dcim',
-	'extras',
-	'ipam',
-	'tenancy',
-	'virtualization',
+    "circuits",
+    "dcim",
+    "extras",
+    "ipam",
+    "tenancy",
+    "virtualization",
 ]
 
 config = django.conf.settings.RBAC
 
 # Custom applications? Patch those too.
-if 'APPS' in config:
-	apps += config['APPS']
+if "APPS" in config:
+    apps += config["APPS"]
+
 
 class AppConfig(django.apps.AppConfig):
-	name = 'netbox_rbac'
+    name = "netbox_rbac"
 
-	def ready(self):
-		from .mixins import PermissionRequiredMixin
+    def ready(self):
+        from .mixins import PermissionRequiredMixin
 
-		# For each view in each app, replace PermissionRequiredMixin with ours.
-		for app in apps:
-			module = importlib.import_module('%s.views' % app)
+        # For each view in each app, replace PermissionRequiredMixin with ours.
+        for app in apps:
+            module = importlib.import_module("%s.views" % app)
 
-			for name, obj in inspect.getmembers(module, inspect.isclass):
-				if obj.__module__ == module.__name__:
-					bases = list(obj.__bases__)
+            for name, obj in inspect.getmembers(module, inspect.isclass):
+                if obj.__module__ == module.__name__:
+                    bases = list(obj.__bases__)
 
-					for i, base in enumerate(bases):
-						if base.__name__ == 'PermissionRequiredMixin':
-							bases[i] = PermissionRequiredMixin
+                    for i, base in enumerate(bases):
+                        if base.__name__ == "PermissionRequiredMixin":
+                            bases[i] = PermissionRequiredMixin
 
-					obj.__bases__ = tuple(bases)
+                    obj.__bases__ = tuple(bases)
 
-		# Patch views which don't otherwise have an easy way to get objects.
-		import dcim.models
-		import dcim.views
+        # Patch views which don't otherwise have an easy way to get objects.
+        import dcim.models
+        import dcim.views
 
-		patch = [
-			(dcim.views.VirtualChassisAddMemberView,    dcim.models.VirtualChassis),
-			(dcim.views.VirtualChassisEditView,         dcim.models.VirtualChassis),
-			(dcim.views.VirtualChassisRemoveMemberView, dcim.models.VirtualChassis),
-		]
+        patch = [
+            (dcim.views.VirtualChassisAddMemberView, dcim.models.VirtualChassis),
+            (dcim.views.VirtualChassisEditView, dcim.models.VirtualChassis),
+            (dcim.views.VirtualChassisRemoveMemberView, dcim.models.VirtualChassis),
+        ]
 
-		for view, model in patch:
-			setattr(view, 'get_object',
-				lambda self, kwargs: model.objects.get(pk=kwargs['pk']))
+        for view, model in patch:
+            setattr(
+                view,
+                "get_object",
+                lambda self, kwargs: model.objects.get(pk=kwargs["pk"]),
+            )

--- a/netbox_rbac/auth/__init__.py
+++ b/netbox_rbac/auth/__init__.py
@@ -2,17 +2,14 @@ import collections
 
 from . import ldap, mock
 
-Account = collections.namedtuple('Account', [
-	'email',
-	'first_name',
-	'last_name',
-])
+Account = collections.namedtuple("Account", ["email", "first_name", "last_name",])
+
 
 def load(config):
-	if 'LDAP' in config:
-		return ldap.Driver(config['LDAP'])
+    if "LDAP" in config:
+        return ldap.Driver(config["LDAP"])
 
-	if 'MOCK' in config:
-		return mock.Driver(config['MOCK'])
+    if "MOCK" in config:
+        return mock.Driver(config["MOCK"])
 
-	raise Exception('no auth driver configured')
+    raise Exception("no auth driver configured")

--- a/netbox_rbac/auth/ldap.py
+++ b/netbox_rbac/auth/ldap.py
@@ -5,80 +5,83 @@ from .. import auth
 # Required when using self-signed certificates.
 ldap.set_option(ldap.OPT_X_TLS_REQUIRE_CERT, ldap.OPT_X_TLS_NEVER)
 
-class Driver:
-	def __init__(self, config):
-		self.config = config
 
-	def session(self):
-		return Session(**self.config)
+class Driver:
+    def __init__(self, config):
+        self.config = config
+
+    def session(self):
+        return Session(**self.config)
+
 
 class Session:
-	def __init__(self, domain, search, server):
-		self.domain = domain
-		self.search = search
+    def __init__(self, domain, search, server):
+        self.domain = domain
+        self.search = search
 
-		# Cache group membership to avoid repeated lookups.
-		self.groups = {}
+        # Cache group membership to avoid repeated lookups.
+        self.groups = {}
 
-		# Connect, and ensure the connection is encrypted.
-		self.client = ldap.initialize(server)
-		self.client.start_tls_s()
+        # Connect, and ensure the connection is encrypted.
+        self.client = ldap.initialize(server)
+        self.client.start_tls_s()
 
-	def authenticate(self, username, password):
-		# Authenticate as the user.
-		self.client.simple_bind_s(self.domain + '\\' + username, password)
+    def authenticate(self, username, password):
+        # Authenticate as the user.
+        self.client.simple_bind_s(self.domain + "\\" + username, password)
 
-		# Retrieve user attributes.
-		result = self.lookup('user', username)
+        # Retrieve user attributes.
+        result = self.lookup("user", username)
 
-		if not result:
-			raise Exception('search: no results')
+        if not result:
+            raise Exception("search: no results")
 
-		# Each result is a tuple: (distinguishedName, attributes)
-		attrs = result[1]
-		props = {
-			'email':      'mail',
-			'first_name': 'givenName',
-			'last_name':  'sn',
-		}
+        # Each result is a tuple: (distinguishedName, attributes)
+        attrs = result[1]
+        props = {
+            "email": "mail",
+            "first_name": "givenName",
+            "last_name": "sn",
+        }
 
-		# Map from LDAP attributes to account properties.
-		for prop, attr in props.items():
-			props[prop] = ''
+        # Map from LDAP attributes to account properties.
+        for prop, attr in props.items():
+            props[prop] = ""
 
-			if attr in attrs and attrs[attr]:
-				props[prop] = attrs[attr][0].decode('utf8')
+            if attr in attrs and attrs[attr]:
+                props[prop] = attrs[attr][0].decode("utf8")
 
-		return auth.Account(**props)
+        return auth.Account(**props)
 
-	def close(self):
-		self.client.unbind_ext_s()
+    def close(self):
+        self.client.unbind_ext_s()
 
-	def lookup(self, kind, *args):
-		results = self.client.search_s(
-			self.search[kind]['base'], ldap.SCOPE_SUBTREE,
-			self.search[kind]['filter'] % tuple(args)
-		)
+    def lookup(self, kind, *args):
+        results = self.client.search_s(
+            self.search[kind]["base"],
+            ldap.SCOPE_SUBTREE,
+            self.search[kind]["filter"] % tuple(args),
+        )
 
-		return next(iter(results), None)
+        return next(iter(results), None)
 
-	def member(self, username, groups):
-		for group in groups:
-			# Populate the cache for this group, if necessary.
-			if group not in self.groups:
-				self.groups[group] = self.member_query(username, group)
+    def member(self, username, groups):
+        for group in groups:
+            # Populate the cache for this group, if necessary.
+            if group not in self.groups:
+                self.groups[group] = self.member_query(username, group)
 
-			if self.groups[group]:
-				return True
+            if self.groups[group]:
+                return True
 
-		return False
+        return False
 
-	def member_query(self, username, group):
-		# Get the DN of the group.
-		group = self.lookup('group', group)
+    def member_query(self, username, group):
+        # Get the DN of the group.
+        group = self.lookup("group", group)
 
-		# Get membership.
-		if group and self.lookup('member', username, group[0]):
-			return True
+        # Get membership.
+        if group and self.lookup("member", username, group[0]):
+            return True
 
-		return False
+        return False

--- a/netbox_rbac/auth/mock.py
+++ b/netbox_rbac/auth/mock.py
@@ -1,40 +1,44 @@
 from .. import auth
 
-class Driver:
-	def __init__(self, config):
-		self.config = config
 
-	def session(self):
-		return Session(**self.config)
+class Driver:
+    def __init__(self, config):
+        self.config = config
+
+    def session(self):
+        return Session(**self.config)
+
 
 class Session:
-	def __init__(self, users):
-		self.users  = users
-		self.groups = []
+    def __init__(self, users):
+        self.users = users
+        self.groups = []
 
-	def authenticate(self, username, password):
-		user = filter(lambda u: u['username'] == username and \
-		                        u['password'] == password, self.users)
+    def authenticate(self, username, password):
+        user = filter(
+            lambda u: u["username"] == username and u["password"] == password,
+            self.users,
+        )
 
-		user = next(user, None)
+        user = next(user, None)
 
-		if not user:
-			raise Exception('invalid credentials')
+        if not user:
+            raise Exception("invalid credentials")
 
-		self.groups = user['groups']
+        self.groups = user["groups"]
 
-		return auth.Account(
-			email      = user['email'],
-			first_name = user['first_name'],
-			last_name  = user['last_name'],
-		)
+        return auth.Account(
+            email=user["email"],
+            first_name=user["first_name"],
+            last_name=user["last_name"],
+        )
 
-	def close(self):
-		pass
+    def close(self):
+        pass
 
-	def member(self, username, groups):
-		for group in groups:
-			if group in self.groups:
-				return True
+    def member(self, username, groups):
+        for group in groups:
+            if group in self.groups:
+                return True
 
-		return False
+        return False

--- a/netbox_rbac/backend.py
+++ b/netbox_rbac/backend.py
@@ -1,7 +1,7 @@
 import cachetools
 import django.conf
 
-from django.core.exceptions     import PermissionDenied
+from django.core.exceptions import PermissionDenied
 from django.contrib.auth.models import User
 
 from . import auth, models, rule
@@ -11,73 +11,74 @@ from . import auth, models, rule
 # well as flush periodically to ensure we're using the latest rules.
 @cachetools.cached(cache=cachetools.TTLCache(maxsize=128, ttl=60))
 def cached_config(key):
-	config = django.conf.settings.RBAC
+    config = django.conf.settings.RBAC
 
-	if key == 'auth':
-		return auth.load(config['AUTH'])
+    if key == "auth":
+        return auth.load(config["AUTH"])
 
-	if key == 'rule':
-		return rule.load(config['RULE'])
+    if key == "rule":
+        return rule.load(config["RULE"])
 
-	raise Exception('cached_config: unknown key: %s' % key)
+    raise Exception("cached_config: unknown key: %s" % key)
+
 
 class Backend:
-	def __init__(self, **kwargs):
-		self.auth = kwargs.get('auth', cached_config('auth'))
-		self.rule = kwargs.get('rule', cached_config('rule'))
+    def __init__(self, **kwargs):
+        self.auth = kwargs.get("auth", cached_config("auth"))
+        self.rule = kwargs.get("rule", cached_config("rule"))
 
-	def authenticate(self, request, username=None, password=None):
-		sn = self.auth.session()
+    def authenticate(self, request, username=None, password=None):
+        sn = self.auth.session()
 
-		try:
-			account = sn.authenticate(username, password)
-		except:
-			raise PermissionDenied
+        try:
+            account = sn.authenticate(username, password)
+        except:
+            raise PermissionDenied
 
-		# Credentials are valid. Ensure the user object exists.
-		user, _ = User.objects.get_or_create(username=username)
+        # Credentials are valid. Ensure the user object exists.
+        user, _ = User.objects.get_or_create(username=username)
 
-		# Determine roles from group membership.
-		roles = set()
+        # Determine roles from group membership.
+        roles = set()
 
-		for name, role in self.rule.roles.items():
-			if sn.member(username, role.groups):
-				roles.add(name)
+        for name, role in self.rule.roles.items():
+            if sn.member(username, role.groups):
+                roles.add(name)
 
-		user.email      = account.email
-		user.first_name = account.first_name
-		user.last_name  = account.last_name
+        user.email = account.email
+        user.first_name = account.first_name
+        user.last_name = account.last_name
 
-		if '_is_denied' in roles:
-			roles.clear()
+        if "_is_denied" in roles:
+            roles.clear()
 
-		user.is_active    = '_is_active' in roles
-		user.is_staff     = '_is_staff'  in roles
-		user.is_superuser = '_is_super'  in roles
+        user.is_active = "_is_active" in roles
+        user.is_staff = "_is_staff" in roles
+        user.is_superuser = "_is_super" in roles
 
-		user.save()
+        user.save()
 
-		profile, _ = models.Profile.objects.get_or_create(user=user)
+        profile, _ = models.Profile.objects.get_or_create(user=user)
 
-		profile.roles = sorted(list(roles))
-		profile.save()
+        profile.roles = sorted(list(roles))
+        profile.save()
 
-		# Close the session.
-		sn.close()
+        # Close the session.
+        sn.close()
 
-		return user
+        return user
 
-	def get_user(self, user_id):
-		user = User.objects.get(pk=user_id)
+    def get_user(self, user_id):
+        user = User.objects.get(pk=user_id)
 
-		# Ensure each user has a profile.
-		if user and not hasattr(user, 'profile'):
-			models.Profile.objects.create(user=user)
+        # Ensure each user has a profile.
+        if user and not hasattr(user, "profile"):
+            models.Profile.objects.create(user=user)
 
-		return user
+        return user
 
-	def has_perm(self, user_obj, perm, obj=None):
-		if hasattr(user_obj, 'profile'):
-			return self.rule.has_perm(user_obj.profile.roles, perm, obj)
+    def has_perm(self, user_obj, perm, obj=None):
+        if hasattr(user_obj, "profile"):
+            return self.rule.has_perm(user_obj.profile.roles, perm, obj)
 
-		return False
+        return False

--- a/netbox_rbac/macros.py
+++ b/netbox_rbac/macros.py
@@ -1,29 +1,33 @@
 from wcmatch.fnmatch import fnmatch
 
+
 def get(obj, path):
-	for attr in path.split('.'):
-		if not hasattr(obj, attr):
-			return None
+    for attr in path.split("."):
+        if not hasattr(obj, attr):
+            return None
 
-		obj = getattr(obj, attr)
+        obj = getattr(obj, attr)
 
-	return obj
+    return obj
+
 
 def match(obj, *args):
-	*paths, values = args
+    *paths, values = args
 
-	return _walk_match(obj, paths, values, False)
+    return _walk_match(obj, paths, values, False)
+
 
 def match_or_none(obj, *args):
-	*paths, values = args
+    *paths, values = args
 
-	return _walk_match(obj, paths, values, True)
+    return _walk_match(obj, paths, values, True)
+
 
 def _walk_match(obj, paths, values, default):
-	for path in paths:
-		value = get(obj, path)
+    for path in paths:
+        value = get(obj, path)
 
-		if value is not None:
-			return fnmatch(value, values)
+        if value is not None:
+            return fnmatch(value, values)
 
-	return default
+    return default

--- a/netbox_rbac/middleware.py
+++ b/netbox_rbac/middleware.py
@@ -1,71 +1,70 @@
 import functools
 import threading
 
-from django.core.exceptions   import PermissionDenied
+from django.core.exceptions import PermissionDenied
 from django.db.models.signals import m2m_changed, pre_save
 
 # Ignore changes related to authentication.
 ignore_modules = [
-	'django.contrib.auth.models',
-	'django.contrib.sessions.models',
-	'netbox_rbac.models',
+    "django.contrib.auth.models",
+    "django.contrib.sessions.models",
+    "netbox_rbac.models",
 ]
 
 # Track the current request so rules can evaluate request attributes.
 requests = {}
 
+
 def request():
-	return requests.get(threading.current_thread())
+    return requests.get(threading.current_thread())
+
 
 class Middleware:
-	def __init__(self, get_response):
-		self.get_response = get_response
+    def __init__(self, get_response):
+        self.get_response = get_response
 
-	def __call__(self, request):
-		handler = functools.partial(self.has_perm, request)
-		signals = (m2m_changed, pre_save)
+    def __call__(self, request):
+        handler = functools.partial(self.has_perm, request)
+        signals = (m2m_changed, pre_save)
 
-		requests[threading.current_thread()] = request
+        requests[threading.current_thread()] = request
 
-		for signal in signals:
-			signal.connect(handler)
+        for signal in signals:
+            signal.connect(handler)
 
-		response = self.get_response(request)
+        response = self.get_response(request)
 
-		for signal in signals:
-			signal.disconnect(handler)
+        for signal in signals:
+            signal.disconnect(handler)
 
-		del requests[threading.current_thread()]
+        del requests[threading.current_thread()]
 
-		return response
+        return response
 
-	def has_perm(self, request, instance, **kwargs):
-		if instance.__module__ in ignore_modules:
-			return
+    def has_perm(self, request, instance, **kwargs):
+        if instance.__module__ in ignore_modules:
+            return
 
-		# Determining the correct permission is surprisingly tricky.
-		#
-		# Operations performed via the REST API follow the typical REST method
-		# convention, so we borrow the mapping from the Django REST framework.
-		#
-		# Operations performed via the web UI are less consistent, and mostly
-		# use the POST method, so we have to see if the object already has a
-		# primary key in order to distinguish between 'add' and 'change'.
-		method_operation = {
-			'DELETE': 'delete',
-			'GET':    'view',
-			'HEAD':   'view',
-			'PATCH':  'change',
-			'POST':   'add',
-			'PUT':    'change',
-		}
+        # Determining the correct permission is surprisingly tricky.
+        #
+        # Operations performed via the REST API follow the typical REST method
+        # convention, so we borrow the mapping from the Django REST framework.
+        #
+        # Operations performed via the web UI are less consistent, and mostly
+        # use the POST method, so we have to see if the object already has a
+        # primary key in order to distinguish between 'add' and 'change'.
+        method_operation = {
+            "DELETE": "delete",
+            "GET": "view",
+            "HEAD": "view",
+            "PATCH": "change",
+            "POST": "add",
+            "PUT": "change",
+        }
 
-		oper = 'change' if instance.pk else method_operation[request.method]
+        oper = "change" if instance.pk else method_operation[request.method]
 
-		perm = '%s.%s_%s' % (
-			instance._meta.app_label, oper,
-			instance._meta.model_name,
-		)
+        perm = "%s.%s_%s" % (instance._meta.app_label, oper, instance._meta.model_name,)
 
-		if not request.user.has_perms([perm], instance):
-			raise PermissionDenied('%s %s' % (oper, instance))
+        if not request.user.has_perms([perm], instance):
+            raise PermissionDenied("%s %s" % (oper, instance))

--- a/netbox_rbac/mixins.py
+++ b/netbox_rbac/mixins.py
@@ -1,48 +1,49 @@
 import collections
 import re
 
-from django.contrib.auth    import mixins
+from django.contrib.auth import mixins
 from django.core.exceptions import PermissionDenied
 
+
 class PermissionRequiredMixin(mixins.PermissionRequiredMixin):
-	def get_permission_objects(self):
-		# Single object view.
-		if hasattr(self, 'get_object') and callable(self.get_object):
-			return [self.get_object(self.kwargs)]
+    def get_permission_objects(self):
+        # Single object view.
+        if hasattr(self, "get_object") and callable(self.get_object):
+            return [self.get_object(self.kwargs)]
 
-		# Multiple objects view.
-		pks = [int(pk) for pk in self.request.POST.getlist('pk')]
+        # Multiple objects view.
+        pks = [int(pk) for pk in self.request.POST.getlist("pk")]
 
-		if pks and hasattr(self, 'queryset'):
-			return self.queryset.model.objects.filter(pk__in=pks).iterator()
+        if pks and hasattr(self, "queryset"):
+            return self.queryset.model.objects.filter(pk__in=pks).iterator()
 
-		return [None]
+        return [None]
 
-	def has_permission(self):
-		objects     = self.get_permission_objects()
-		permissions = self.get_permission_required()
+    def has_permission(self):
+        objects = self.get_permission_objects()
+        permissions = self.get_permission_required()
 
-		denied = collections.defaultdict(list)
+        denied = collections.defaultdict(list)
 
-		for obj in objects:
-			for perm in permissions:
-				if self.request.user.has_perms([perm], obj):
-					continue
+        for obj in objects:
+            for perm in permissions:
+                if self.request.user.has_perms([perm], obj):
+                    continue
 
-				# Extract the operation from the permission:
-				#   <app>.<operation>_<class>
-				match = re.match('^\w+\.([^_]+)', perm)
+                # Extract the operation from the permission:
+                #   <app>.<operation>_<class>
+                match = re.match("^\w+\.([^_]+)", perm)
 
-				# If the object is uninitialized, display something useful.
-				if not str(obj):
-					obj = obj._meta.verbose_name_plural
+                # If the object is uninitialized, display something useful.
+                if not str(obj):
+                    obj = obj._meta.verbose_name_plural
 
-				denied[match.group(1)].append(str(obj))
+                denied[match.group(1)].append(str(obj))
 
-		if not denied:
-			return True
+        if not denied:
+            return True
 
-		# Display a more informative exception.
-		raise PermissionDenied(', '.join(
-			['%s %s' % (op, ', '.join(obj)) for op, obj in denied.items()]
-		))
+        # Display a more informative exception.
+        raise PermissionDenied(
+            ", ".join(["%s %s" % (op, ", ".join(obj)) for op, obj in denied.items()])
+        )

--- a/netbox_rbac/models.py
+++ b/netbox_rbac/models.py
@@ -1,15 +1,12 @@
-from django.contrib.auth.models     import User
+from django.contrib.auth.models import User
 from django.contrib.postgres.fields import ArrayField
-from django.db                      import models
+from django.db import models
+
 
 class Profile(models.Model):
-	user = models.OneToOneField(User, on_delete = models.CASCADE)
+    user = models.OneToOneField(User, on_delete=models.CASCADE)
 
-	roles = ArrayField(
-		models.CharField(max_length = 255),
-		blank   = True,
-		default = list,
-	)
+    roles = ArrayField(models.CharField(max_length=255), blank=True, default=list,)
 
-	class Meta:
-		managed = True
+    class Meta:
+        managed = True

--- a/netbox_rbac/rule.py
+++ b/netbox_rbac/rule.py
@@ -5,109 +5,112 @@ import logging
 import yaml
 
 from inspect import getmembers, isfunction
-from urllib  import parse, request
+from urllib import parse, request
 from wcmatch import fnmatch
 
 from . import macros, middleware
 
-log = logging.getLogger('netbox_rbac')
+log = logging.getLogger("netbox_rbac")
 
 # Collect all public functions from macros.
 functions = [
-	(name, fn) for name, fn in getmembers(macros, isfunction) \
-		if not name.startswith('_')
+    (name, fn)
+    for name, fn in getmembers(macros, isfunction)
+    if not name.startswith("_")
 ]
 
 # In order to guard against external dependencies, such as Gitlab, being
 # unavailable, store the last configuration.
 config = None
 
+
 def load(paths):
-	global config
+    global config
 
-	errors = []
+    errors = []
 
-	for path in paths:
-		try:
-			path = parse.urlparse(path, scheme='file')
-			data = request.urlopen(path.geturl())
+    for path in paths:
+        try:
+            path = parse.urlparse(path, scheme="file")
+            data = request.urlopen(path.geturl())
 
-			config = Rule(yaml.safe_load(data))
+            config = Rule(yaml.safe_load(data))
 
-			return config
+            return config
 
-		except Exception as err:
-			errors.append('%s: %s' % (path.geturl(), err))
-	
-	log.warn('load: no valid rules found: %s', errors)
+        except Exception as err:
+            errors.append("%s: %s" % (path.geturl(), err))
 
-	# Unable to load a new config, so return the current one.
-	return config
+    log.warn("load: no valid rules found: %s", errors)
+
+    # Unable to load a new config, so return the current one.
+    return config
+
 
 class Rule:
-	def __init__(self, config):
-		self.roles = {}
+    def __init__(self, config):
+        self.roles = {}
 
-		# Although YAML provides a mechanism for referencing one object from
-		# another, it doesn't support deep merging, so we handle that manually.
-		for name, role in config.items():
-			for base in role.get('base', []):
-				deepmerge.always_merger.merge(role, config[base])
+        # Although YAML provides a mechanism for referencing one object from
+        # another, it doesn't support deep merging, so we handle that manually.
+        for name, role in config.items():
+            for base in role.get("base", []):
+                deepmerge.always_merger.merge(role, config[base])
 
-			# Ignore template roles.
-			if 'groups' in role:
-				self.roles[name] = Role(name, **role)
+            # Ignore template roles.
+            if "groups" in role:
+                self.roles[name] = Role(name, **role)
 
-	# Given the user's roles, the requested permission, and the object, returns
-	# whether or not the operation is allowed.
-	def has_perm(self, roles, perm, obj):
-		for role in roles:
-			role = self.roles.get(role)
+    # Given the user's roles, the requested permission, and the object, returns
+    # whether or not the operation is allowed.
+    def has_perm(self, roles, perm, obj):
+        for role in roles:
+            role = self.roles.get(role)
 
-			# Permission is granted when:
-			#  * The role is valid (defined in the configuration).
-			#  * The requested permission is granted by the role.
-			#  * The rule evaluates to True on the object.
-			if role and role.has_perm(perm) and role.eval(obj):
-				return True
+            # Permission is granted when:
+            #  * The role is valid (defined in the configuration).
+            #  * The requested permission is granted by the role.
+            #  * The rule evaluates to True on the object.
+            if role and role.has_perm(perm) and role.eval(obj):
+                return True
 
-		return False
+        return False
+
 
 class Role:
-	def __init__(self, name, **kwargs):
-		self.name    = name
-		self.context = kwargs.get('context', {})
-		self.groups  = kwargs.get('groups',  [])
-		self.imports = kwargs.get('imports', [])
-		self.perms   = kwargs.get('perms',   [])
-		self.rule    = kwargs.get('rule')
+    def __init__(self, name, **kwargs):
+        self.name = name
+        self.context = kwargs.get("context", {})
+        self.groups = kwargs.get("groups", [])
+        self.imports = kwargs.get("imports", [])
+        self.perms = kwargs.get("perms", [])
+        self.rule = kwargs.get("rule")
 
-		if self.rule:
-			self.code = compile(self.rule, '<string>', 'eval')
-		else:
-			self.code = None
+        if self.rule:
+            self.code = compile(self.rule, "<string>", "eval")
+        else:
+            self.code = None
 
-	# Returns the result of evaluating the rule on the object, if both are
-	# defined. Returns True otherwise.
-	def eval(self, obj):
-		if self.code and obj:
-			context = {**self.context, 'obj': obj}
+    # Returns the result of evaluating the rule on the object, if both are
+    # defined. Returns True otherwise.
+    def eval(self, obj):
+        if self.code and obj:
+            context = {**self.context, "obj": obj}
 
-			for name in self.imports:
-				context[name] = importlib.import_module(name)
+            for name in self.imports:
+                context[name] = importlib.import_module(name)
 
-			for name, fn in functions:
-				context[name] = functools.partial(fn, obj)
+            for name, fn in functions:
+                context[name] = functools.partial(fn, obj)
 
-			context.update({
-				'fnmatch': fnmatch.fnmatch,
-				'request': middleware.request(),
-			})
+            context.update(
+                {"fnmatch": fnmatch.fnmatch, "request": middleware.request(),}
+            )
 
-			return eval(self.code, context)
+            return eval(self.code, context)
 
-		return True
+        return True
 
-	# Returns whether or not this role provides the requested permission.
-	def has_perm(self, perm):
-		return fnmatch.fnmatch(perm, self.perms)
+    # Returns whether or not this role provides the requested permission.
+    def has_perm(self, perm):
+        return fnmatch.fnmatch(perm, self.perms)

--- a/netbox_rbac/tests/test_macros.py
+++ b/netbox_rbac/tests/test_macros.py
@@ -4,48 +4,49 @@ from netbox_rbac import macros
 
 from netbox_rbac.tests.types import *
 
-r1 = Rack(name='R1', site=None)
-r2 = Rack(name='R2', site=Site(name='DC1'))
+r1 = Rack(name="R1", site=None)
+r2 = Rack(name="R2", site=Site(name="DC1"))
+
 
 class TestMacros:
-	def test_get(self):
-		tests = [
-			( r1, 'name',      'R1'  ),
-			( r1, 'none',      None  ),
-			( r1, 'site',      None  ),
-			( r1, 'site.name', None  ),
-			( r2, 'site.name', 'DC1' ),
-		]
+    def test_get(self):
+        tests = [
+            (r1, "name", "R1"),
+            (r1, "none", None),
+            (r1, "site", None),
+            (r1, "site.name", None),
+            (r2, "site.name", "DC1"),
+        ]
 
-		for obj, path, value in tests:
-			assert macros.get(obj, path) == value
+        for obj, path, value in tests:
+            assert macros.get(obj, path) == value
 
-	def test_match(self):
-		tests = [
-			( r1, 'name',      'R1',           True  ),
-			( r1, 'name',      'R2',           False ),
-			( r1, 'site.name', 'DC1',          False ),
-			( r2, 'site.name', 'DC1',          True  ),
-			( r1, 'site.name', 'DC2',          False ),
-			( r2, 'site.name', 'DC2',          False ),
-			( r2, 'site.name', 'DC*',          True  ),
-			( r2, 'site.name', ['DC1', 'DC2'], True  ),
-		]
+    def test_match(self):
+        tests = [
+            (r1, "name", "R1", True),
+            (r1, "name", "R2", False),
+            (r1, "site.name", "DC1", False),
+            (r2, "site.name", "DC1", True),
+            (r1, "site.name", "DC2", False),
+            (r2, "site.name", "DC2", False),
+            (r2, "site.name", "DC*", True),
+            (r2, "site.name", ["DC1", "DC2"], True),
+        ]
 
-		for obj, path, value, result in tests:
-			assert macros.match(obj, path, value) == result
+        for obj, path, value, result in tests:
+            assert macros.match(obj, path, value) == result
 
-	def test_match_or_none(self):
-		tests = [
-			( r1, 'name',      'R1',           True  ),
-			( r1, 'name',      'R2',           False ),
-			( r1, 'site.name', 'DC1',          True  ),
-			( r2, 'site.name', 'DC1',          True  ),
-			( r1, 'site.name', 'DC2',          True  ),
-			( r2, 'site.name', 'DC2',          False ),
-			( r2, 'site.name', 'DC*',          True  ),
-			( r2, 'site.name', ['DC1', 'DC2'], True  ),
-		]
+    def test_match_or_none(self):
+        tests = [
+            (r1, "name", "R1", True),
+            (r1, "name", "R2", False),
+            (r1, "site.name", "DC1", True),
+            (r2, "site.name", "DC1", True),
+            (r1, "site.name", "DC2", True),
+            (r2, "site.name", "DC2", False),
+            (r2, "site.name", "DC*", True),
+            (r2, "site.name", ["DC1", "DC2"], True),
+        ]
 
-		for obj, path, value, result in tests:
-			assert macros.match_or_none(obj, path, value) == result
+        for obj, path, value, result in tests:
+            assert macros.match_or_none(obj, path, value) == result

--- a/netbox_rbac/tests/test_rule.py
+++ b/netbox_rbac/tests/test_rule.py
@@ -5,65 +5,55 @@ from netbox_rbac import rule
 from netbox_rbac.tests.types import *
 
 config = {
-	# Grants all rack permissions when the rack is in DC1.
-	'dcim_rack_admin_dc1': {
-		'groups': ['DC1-Rack-Admins'],
-		'perms':  ['dcim.*_rack'],
-		'rule':   'obj.site.name == "DC1"'
-	},
-
-	# Grants all rack change permission when the rack is in DC2.
-	'dcim_rack_admin_dc2': {
-		'groups': ['DC2-Rack-Users'],
-		'perms':  ['dcim.change_rack'],
-		'rule':   'obj.site.name == "DC2"'
-	},
-
-	# Grants all permissions to all sites.
-	'dcim_site_admin_all': {
-		'groups': ['DCIM-Site-Admins'],
-		'perms':  ['dcim.*_site'],
-	},
-
-	'import_test': {
-		'groups':  ['DCIM-Site-Admins'],
-		'imports': ['os', 'os.path'],
-		'perms':   ['test.*_import'],
-		'rule':    'os.path.basename("/foo/bar") == "bar"',
-	}
+    # Grants all rack permissions when the rack is in DC1.
+    "dcim_rack_admin_dc1": {
+        "groups": ["DC1-Rack-Admins"],
+        "perms": ["dcim.*_rack"],
+        "rule": 'obj.site.name == "DC1"',
+    },
+    # Grants all rack change permission when the rack is in DC2.
+    "dcim_rack_admin_dc2": {
+        "groups": ["DC2-Rack-Users"],
+        "perms": ["dcim.change_rack"],
+        "rule": 'obj.site.name == "DC2"',
+    },
+    # Grants all permissions to all sites.
+    "dcim_site_admin_all": {"groups": ["DCIM-Site-Admins"], "perms": ["dcim.*_site"],},
+    "import_test": {
+        "groups": ["DCIM-Site-Admins"],
+        "imports": ["os", "os.path"],
+        "perms": ["test.*_import"],
+        "rule": 'os.path.basename("/foo/bar") == "bar"',
+    },
 }
 
+
 class TestRule:
-	def test_rule(self):
-		roles = set(config.keys())
-		rules = rule.Rule(config)
+    def test_rule(self):
+        roles = set(config.keys())
+        rules = rule.Rule(config)
 
-		tests = [
-			# Blank rack, granted by dcim_rack_admin_dc1.
-			( 'dcim.add_rack',    True,  None                                   ),
+        tests = [
+            # Blank rack, granted by dcim_rack_admin_dc1.
+            ("dcim.add_rack", True, None),
+            # Blank region, no roles grant region permissions.
+            ("dcim.add_region", False, None),
+            # DC1 rack, all permissions granted.
+            ("dcim.add_rack", True, Rack(name="R1", site=Site(name="DC1"))),
+            ("dcim.change_rack", True, Rack(name="R1", site=Site(name="DC1"))),
+            ("dcim.delete_rack", True, Rack(name="R1", site=Site(name="DC1"))),
+            # All site permissions granted.
+            ("dcim.add_site", True, None),
+            ("dcim.add_site", True, Site(name="DC1")),
+            ("dcim.change_site", True, Site(name="DC1")),
+            ("dcim.delete_site", True, Site(name="DC1")),
+            # DC2 rack, only changes are allowed.
+            ("dcim.add_rack", False, Rack(name="R1", site=Site(name="DC2"))),
+            ("dcim.change_rack", True, Rack(name="R1", site=Site(name="DC2"))),
+            ("dcim.delete_rack", False, Rack(name="R1", site=Site(name="DC2"))),
+            # Module import test.
+            ("test.test_import", True, Site(name="DC1")),
+        ]
 
-			# Blank region, no roles grant region permissions.
-			( 'dcim.add_region',  False, None                                   ),
-
-			# DC1 rack, all permissions granted.
-			( 'dcim.add_rack',    True,  Rack(name='R1', site=Site(name='DC1')) ),
-			( 'dcim.change_rack', True,  Rack(name='R1', site=Site(name='DC1')) ),
-			( 'dcim.delete_rack', True,  Rack(name='R1', site=Site(name='DC1')) ),
-
-			# All site permissions granted.
-			( 'dcim.add_site',    True,  None                                   ),
-			( 'dcim.add_site',    True,  Site(name='DC1')                       ),
-			( 'dcim.change_site', True,  Site(name='DC1')                       ),
-			( 'dcim.delete_site', True,  Site(name='DC1')                       ),
-
-			# DC2 rack, only changes are allowed.
-			( 'dcim.add_rack',    False, Rack(name='R1', site=Site(name='DC2')) ),
-			( 'dcim.change_rack', True,  Rack(name='R1', site=Site(name='DC2')) ),
-			( 'dcim.delete_rack', False, Rack(name='R1', site=Site(name='DC2')) ),
-
-			# Module import test.
-			( 'test.test_import', True, Site(name='DC1')                        ),
-		]
-
-		for perm, result, obj in tests:
-			assert rules.has_perm(roles, perm, obj) == result
+        for perm, result, obj in tests:
+            assert rules.has_perm(roles, perm, obj) == result

--- a/netbox_rbac/tests/types.py
+++ b/netbox_rbac/tests/types.py
@@ -1,9 +1,9 @@
 from collections import namedtuple
 
 __all__ = [
-	'Rack',
-	'Site',
+    "Rack",
+    "Site",
 ]
 
-Rack = namedtuple('Rack', ['name', 'site'])
-Site = namedtuple('Site', ['name'])
+Rack = namedtuple("Rack", ["name", "site"])
+Site = namedtuple("Site", ["name"])

--- a/netbox_rbac/urls.py
+++ b/netbox_rbac/urls.py
@@ -2,8 +2,8 @@ from django.urls import path
 
 from . import views
 
-app_name = 'rbac'
+app_name = "rbac"
 
 urlpatterns = [
-	path('roles/', views.Roles.as_view(), name='roles'),
+    path("roles/", views.Roles.as_view(), name="roles"),
 ]

--- a/netbox_rbac/views.py
+++ b/netbox_rbac/views.py
@@ -1,14 +1,15 @@
-from django.shortcuts     import render
+from django.shortcuts import render
 from django.views.generic import View
 
 from .backend import Backend
 
-class Roles(View):
-	def get(self, request):
-		backend = Backend()
-		context = {
-			'rule': backend.rule,
-			'user': request.user,
-		}
 
-		return render(request, 'netbox_rbac/roles.html', context)
+class Roles(View):
+    def get(self, request):
+        backend = Backend()
+        context = {
+            "rule": backend.rule,
+            "user": request.user,
+        }
+
+        return render(request, "netbox_rbac/roles.html", context)

--- a/setup.py
+++ b/setup.py
@@ -1,30 +1,30 @@
 import setuptools
 
-with open('README.md', 'r') as fh:
-	long_description = fh.read()
+with open("README.md", "r") as fh:
+    long_description = fh.read()
 
-with open('requirements.txt', 'r') as fh:
-	packages = fh.read().splitlines()
+with open("requirements.txt", "r") as fh:
+    packages = fh.read().splitlines()
 
 setuptools.setup(
-	name='netbox-rbac',
-	version='1.0.12',
-	author='Eric Busto',
-	author_email='ebusto@nvidia.com',
-	description='Opinionated RBAC for NetBox',
-	long_description=long_description,
-	long_description_content_type='text/markdown',
-	url='https://github.com/ebusto/netbox-rbac',
-	packages=setuptools.find_packages(),
-	install_requires=packages,
-	include_package_data=True,
-	zip_safe=False,
-	classifiers=[
-		'Environment :: Web Environment',
-		'Framework :: Django',
-		'Intended Audience :: Developers',
-		'License :: OSI Approved :: MIT License',
-		'Operating System :: OS Independent',
-		'Programming Language :: Python :: 3',
-	],
+    name="netbox-rbac",
+    version="1.0.12",
+    author="Eric Busto",
+    author_email="ebusto@nvidia.com",
+    description="Opinionated RBAC for NetBox",
+    long_description=long_description,
+    long_description_content_type="text/markdown",
+    url="https://github.com/ebusto/netbox-rbac",
+    packages=setuptools.find_packages(),
+    install_requires=packages,
+    include_package_data=True,
+    zip_safe=False,
+    classifiers=[
+        "Environment :: Web Environment",
+        "Framework :: Django",
+        "Intended Audience :: Developers",
+        "License :: OSI Approved :: MIT License",
+        "Operating System :: OS Independent",
+        "Programming Language :: Python :: 3",
+    ],
 )


### PR DESCRIPTION
[Black](https://github.com/psf/black) is a [PEP 8](https://www.python.org/dev/peps/pep-0008/) compatible automatic formatter for Python 3 (but can reformat Python 2 code). 

It does a good job autoformatting, while not necessarily as elegant and readable as hand-formatted PEP8 syntax, it's faster and can be used with CI. 

This PR brings the repository into PEP8 compliance using `black`, without any code changes.